### PR TITLE
timeLineManager in UnreadNotificationManager from private to protected

### DIFF
--- a/src/Spy/Timeline/Notification/Unread/UnreadNotificationManager.php
+++ b/src/Spy/Timeline/Notification/Unread/UnreadNotificationManager.php
@@ -19,7 +19,7 @@ class UnreadNotificationManager implements NotifierInterface
     /**
      * @var TimelineManager
      */
-    private $timelineManager;
+    protected $timelineManager;
 
     /**
      * @param TimelineManagerInterface $timelineManager timelineManager


### PR DESCRIPTION
I have extended your UnreadNotificationManager in my own application in order to only overwrite the notify function, but i would like to keep the other functions from the original UnreadNotificationManager. Therefore the timeLineManager property has to be protected that my NotificationManager can access it.
