### PR TITLE
Fix of Fatal Error due to previous interface changes

### DIFF
--- a/src/Spy/Timeline/ResultBuilder/Pager/PagerInterface.php
+++ b/src/Spy/Timeline/ResultBuilder/Pager/PagerInterface.php
@@ -7,7 +7,7 @@ namespace Spy\Timeline\ResultBuilder\Pager;
  *
  * @author Stephane PY <py.stephane1@gmail.com>
  */
-interface PagerInterface extends \ArrayAccess
+interface PagerInterface
 {
     /**
      * @param mixed $target  target


### PR DESCRIPTION
Fatal error: Class Spy\TimelineBundle\Driver\ODM\Pager contains 4
abstract methods and must therefore be declared abstract or implement
the remaining methods (ArrayAccess::offsetExists,
ArrayAccess::offsetGet, ArrayAccess::offsetSet, ...) in
/var/www/Kolektado/vendor/stephpy/TimelineBundle/Spy/TimelineBundle/Driv
er/ODM/Pager.php on line 113
