### PR TITLE
Phpdoc fix

### DIFF
--- a/src/Spy/Timeline/Model/ActionInterface.php
+++ b/src/Spy/Timeline/Model/ActionInterface.php
@@ -160,7 +160,7 @@ interface ActionInterface
     public function addActionComponent(ActionComponentInterface $actionComponent);
 
     /**
-     * @return ArrayCollection
+     * @return ActionComponentInterface[]
      */
     public function getActionComponents();
 }


### PR DESCRIPTION
ArrayCollection requires a doctrine commons use statement. Since Timeline does not require doctrine common this is not an option.
Using ActionComponentInterface[] helps when working with editors like PHPStorm. 
