### PR TITLE
LocatorInterface phpdoc fixes

### DIFF
--- a/src/Spy/Timeline/Filter/DataHydrator/Locator/LocatorInterface.php
+++ b/src/Spy/Timeline/Filter/DataHydrator/Locator/LocatorInterface.php
@@ -12,6 +12,8 @@ use Spy\Timeline\Model\ComponentInterface;
 interface LocatorInterface
 {
     /**
+     * Decides whether we support the given string representation of the model.
+     *
      * @param string $model model
      *
      * @return boolean
@@ -19,10 +21,12 @@ interface LocatorInterface
     public function supports($model);
 
     /**
-     * @param string                    $model      model
-     * @param array<ComponentInterface> $components components
+     * Sets the data for the given components.
      *
-     * @return array
+     * This method populates the data for the given components by calling setData on those components.
+     *
+     * @param string               $model      model
+     * @param ComponentInterface[] $components Array with components for whom we populate the data by calling setData
      */
     public function locate($model, array $components);
 }


### PR DESCRIPTION
- locate should not return an array. 
- Also for some reason my PHPStorm does not like  `array<ComponentInterface>` so I changed it to `ComponentInterface[]`
- I also added some documentation, it's not great but it's something... 

If you want me to revert the second or last change just let me know :wink: 
