### PR TITLE
phpdoc fixes

### DIFF
--- a/src/Spy/Timeline/Model/ActionComponentInterface.php
+++ b/src/Spy/Timeline/Model/ActionComponentInterface.php
@@ -3,7 +3,7 @@
 namespace Spy\Timeline\Model;
 
 /**
- * ActionComponentInterface
+ * The action component links the actions to the components.
  *
  * @author Stephane PY <py.stephane1@gmail.com>
  */
@@ -15,7 +15,8 @@ interface ActionComponentInterface
     public function isText();
 
     /**
-     * @param  string                   $id id
+     * @param string $id id
+     *
      * @return ActionComponentInterface
      */
     public function setId($id);
@@ -26,7 +27,8 @@ interface ActionComponentInterface
     public function getId();
 
     /**
-     * @param  string          $type
+     * @param string $type for example DirectComplement, Subject
+     *
      * @return ActionComponent
      */
     public function setType($type);
@@ -37,7 +39,8 @@ interface ActionComponentInterface
     public function getType();
 
     /**
-     * @param  string          $text
+     * @param string $text
+     *
      * @return ActionComponent
      */
     public function setText($text);
@@ -48,7 +51,8 @@ interface ActionComponentInterface
     public function getText();
 
     /**
-     * @param  ActionInterface $action
+     * @param ActionInterface $action
+     *
      * @return ActionComponent
      */
     public function setAction(ActionInterface $action);
@@ -59,7 +63,8 @@ interface ActionComponentInterface
     public function getAction();
 
     /**
-     * @param  ComponentInterface $component
+     * @param ComponentInterface $component
+     *
      * @return ActionComponent
      */
     public function setComponent(ComponentInterface $component);


### PR DESCRIPTION
cleaned up too many spaces and no new line before return in actioncomponentinterface

By the way could you let me know if you are interested in those pull requests or not. I'm trying to understand this library (I don't like magic and I'm building some more functionality on top of it)

Also it helps me in learning some git commands.

But most of my fixes are just phpdoc fixes (in PHPstorm there are a lot of 'warnings' (lines under methods) if the phpdoc is wrong. If you'd rather not have pull requests for those I won't bother you with them anymore :wink:
