### PR TITLE
abstract action manager manages the class strings

### DIFF
--- a/src/Spy/Timeline/Driver/AbstractActionManager.php
+++ b/src/Spy/Timeline/Driver/AbstractActionManager.php
@@ -19,10 +19,38 @@ abstract class AbstractActionManager implements ActionManagerInterface
     protected $deployer;
 
     /**
+     * @var string FQCN af the action class
+     */
+    protected $actionClass;
+
+    /**
+     * @var string FQCN of the action component class
+     */
+    protected $componentClass;
+
+    /**
+     * @var string FQCN of the component class
+     */
+    protected $actionComponentClass;
+
+    /**
+     * @param string $actionClass          FQCN of the action class
+     * @param string $componentClass       FQCN of the component class
+     * @param string $actionComponentClass FQCN of the action component class
+     */
+    public function __construct($actionClass, $componentClass, $actionComponentClass)
+    {
+        $this->actionClass = $actionClass;
+        $this->componentClass = $componentClass;
+        $this->actionComponentClass = $actionComponentClass;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function create($subject, $verb, array $components = array())
     {
+        /** @var $action ActionInterface */
         $action = new $this->actionClass();
         $action->setVerb($verb);
 

--- a/src/Spy/Timeline/Driver/Redis/ActionManager.php
+++ b/src/Spy/Timeline/Driver/Redis/ActionManager.php
@@ -35,21 +35,6 @@ class ActionManager extends AbstractActionManager implements ActionManagerInterf
     protected $prefix;
 
     /**
-     * @var string
-     */
-    protected $actionClass;
-
-    /**
-     * @var string
-     */
-    protected $componentClass;
-
-    /**
-     * @var string
-     */
-    protected $actionComponentClass;
-
-    /**
      * @param object                  $client               client
      * @param ResultBuilderInterface $resultBuilder        resultBuilder
      * @param string                  $prefix               prefix
@@ -61,10 +46,9 @@ class ActionManager extends AbstractActionManager implements ActionManagerInterf
     {
         $this->client               = $client;
         $this->prefix               = $prefix;
-        $this->actionClass          = $actionClass;
-        $this->componentClass       = $componentClass;
-        $this->actionComponentClass = $actionComponentClass;
         $this->resultBuilder        = $resultBuilder;
+
+        parent::__construct($actionClass, $componentClass, $actionComponentClass);
     }
 
     /**


### PR DESCRIPTION
This pull request makes the abstract action manager responsible for handling the properties of the class strings.
- In the current code the abstract action manager has knowledge about protected properties from child classes. This causes a warning in my editor

I'll also do a pull request for the bundle.
